### PR TITLE
changed nuget.psm1 and tools.psm1

### DIFF
--- a/Nuget.psm1
+++ b/Nuget.psm1
@@ -18,9 +18,9 @@ Import-Module $PSScriptRoot\tools.psm1
 [DscResource()]
 class Nuget_Module {
   #Declare Properties
-  [DscProperty(Key)]
-  [ensures] $Ensure
   [DscProperty(Mandatory)]
+  [ensures] $Ensure
+  [DscProperty(Key)]
   [string] $Name
   [DscProperty()]
   [string] $Version

--- a/tools.psm1
+++ b/tools.psm1
@@ -33,7 +33,11 @@ function Module {
     Set {
       switch ($Ensure) {
         Present {
-          Find-Module -Repository $ProviderName -Name $Name -RequiredVersion $Version | Install-Module -Force -Scope AllUsers
+          if ($Version) {
+            Find-Module -Repository $ProviderName -Name $Name -RequiredVersion $Version | Install-Module -Force -Scope AllUsers
+          } else {
+            Find-Module -Repository $ProviderName -Name $Name | Install-Module -Force -Scope AllUsers
+          }
         }
         Absent {
           Uninstall-Module -Name $Name -Force


### PR DESCRIPTION
Nuget.psm1 -> Nuget_Module class -> switched key from ensure to name param to be able to add more config blocks for each module you want.

tools.psm1 -> function Module -> Set block:  added if else block for the version parameter. The version parameter in the Nuget_Module class is not mandatory, but if you don't provide a version, the configuration will fail, because the version parameter is empty.